### PR TITLE
Python 3 support

### DIFF
--- a/mailmate/pkgmeta.py
+++ b/mailmate/pkgmeta.py
@@ -5,4 +5,4 @@ pkgmeta = dict(
 )
 
 globals().update(pkgmeta)
-__all__ = pkgmeta.keys()
+__all__ = tuple(pkgmeta.keys())

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import sys
 
 
 pkgmeta = {}
-execfile(os.path.join(os.path.dirname(__file__),
-         'mailmate', 'pkgmeta.py'), pkgmeta)
+exec(open(os.path.join(os.path.dirname(__file__),
+         'mailmate', 'pkgmeta.py')).read(), pkgmeta)
 
 
 class PyTest(TestCommand):

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,27 @@
 [tox]
 envlist =
-    py27-django15, py27-django14, py27-django13,
-    py26-django15, py26-django14, py26-django13,
+    py35-django19, py35-django18,
+    py27-django19, py27-django18,
 
 [testenv]
 commands = python setup.py test
 
-[testenv:py27-django15]
+[testenv:py35-django19]
+basepython = python3.5
+deps =
+    Django>=1.9,<1.10
+
+[testenv:py35-django18]
+basepython = python3.5
+deps =
+    Django>=1.8,<1.9
+
+[testenv:py27-django19]
 basepython = python2.7
 deps =
-    Django>=1.5,<1.6
+    Django>=1.9,<1.10
 
-[testenv:py27-django14]
+[testenv:py27-django18]
 basepython = python2.7
 deps =
-    Django>=1.4,<1.5
-
-[testenv:py27-django13]
-basepython = python2.7
-deps =
-    Django>=1.3,<1.4
-
-[testenv:py26-django15]
-basepython = python2.6
-deps =
-    Django>=1.5,<1.6
-
-[testenv:py26-django14]
-basepython = python2.6
-deps =
-    Django>=1.4,<1.5
-
-[testenv:py26-django13]
-basepython = python2.6
-deps =
-    Django>=1.3,<1.4
+    Django>=1.8,<1.9


### PR DESCRIPTION
This commit includes the necessary changes to get mailmate working on Python 3. I've also removed tests for outdated versions of Django.

While tox runs successfully on my machine, python-markdownify does not (yet) support Python 3. I've opened a pull request on that project for Python 3 support.

https://github.com/matthewwithanm/python-markdownify/pull/1.