### PR TITLE
Update setup.py to not require flake8 on install

### DIFF
--- a/mailmate/pkgmeta.py
+++ b/mailmate/pkgmeta.py
@@ -1,7 +1,7 @@
 pkgmeta = dict(
     __title__='django-mailmate',
     __author__='Chris McKenzie, Matthew Tretter, Colin Wood, Mohammad Taleb, Eric Eldredge',
-    __version__='1.1.0',
+    __version__='1.1.1',
 )
 
 globals().update(pkgmeta)

--- a/mailmate/pkgmeta.py
+++ b/mailmate/pkgmeta.py
@@ -1,7 +1,7 @@
 pkgmeta = dict(
     __title__='django-mailmate',
     __author__='Chris McKenzie, Matthew Tretter, Colin Wood, Mohammad Taleb, Eric Eldredge',
-    __version__='1.1.1',
+    __version__='1.1.0',
 )
 
 globals().update(pkgmeta)

--- a/setup.py
+++ b/setup.py
@@ -67,12 +67,11 @@ setup(
     url='http://github.com/hzdg/django-mailmate',
     long_description=open('README.rst').read(),
     zip_safe=False,
-    setup_requires=[
-        'flake8',
-    ],
+    setup_requires=[],
     tests_require=[
         'pytest-django==2.6',
         'markdownify',
+        'flake8',
     ],
     install_requires=[
         'Django>=1.2',


### PR DESCRIPTION
This was causing installation errors on environments with old versions of pip and setuptools